### PR TITLE
Implement `getState` and `saveState` in `LocalStorageService`

### DIFF
--- a/claude-tasks/2_implement_local_storage_service/chat.md
+++ b/claude-tasks/2_implement_local_storage_service/chat.md
@@ -1,0 +1,51 @@
+# Local Storage Service Implementation Chat
+
+This conversation covers the implementation of the LocalStorageService with saveState and getState methods.
+
+## Summary
+
+Successfully implemented the LocalStorageService with the following features:
+
+1. **saveState method**: Serializes and stores the full State object to localStorage using key 'palabs-app-state'
+   - Returns true on success, false on failure
+   - Overwrites existing state if present
+
+2. **getState method**: Retrieves and deserializes the State from localStorage
+   - Returns deserialized State object on success
+   - Returns null if no state exists or deserialization fails
+   - Clears localStorage if deserialization fails
+
+3. **Comprehensive testing**: Added unit tests covering all scenarios:
+   - Successful save and retrieval
+   - Overwriting existing state
+   - Handling localStorage errors
+   - Handling missing state
+   - Handling invalid JSON
+
+4. **Documentation**: Added JSDoc comments to the service class and both methods
+
+## Technical Notes
+
+- JSON serialization doesn't preserve `undefined` values, so `typedIndex: undefined` properties in Letter objects are removed during serialization
+- Tests account for this behavior using `jasmine.objectContaining()` for flexible matching
+- Achieved 100% code coverage
+- All lint checks pass
+
+## Files Modified
+
+- `src/app/3. services/local-storage.service.ts` - Implementation
+- `src/app/3. services/local-storage.service.spec.ts` - Tests
+
+## Commit
+
+```
+feat: implement local storage service with state persistence
+
+Added saveState and getState methods to LocalStorageService:
+- saveState serializes and stores the full State object to localStorage
+- getState retrieves and deserializes the State from localStorage
+- Returns null and clears storage if deserialization fails
+- Includes comprehensive unit tests with 100% code coverage
+```
+
+The implementation is complete and pushed to the remote repository.

--- a/claude-tasks/2_implement_local_storage_service/prompt.md
+++ b/claude-tasks/2_implement_local_storage_service/prompt.md
@@ -1,0 +1,153 @@
+# Claude Code Prompt Template for Atomic Feature Development
+
+## Core Directive
+
+You are operating under STRICT IMPLEMENTATION MODE. You must:
+1. NEVER make assumptions or "fill in the blanks"
+2. STOP and ASK when any detail is unclear
+3. REFUSE to implement if specifications are ambiguous
+4. ONLY write code that is explicitly requested
+5. CREATE only atomic, single-purpose changes
+
+## Prompt Template
+
+```
+I need you to implement the following specific change. This should be ONE atomic commit.
+
+## STRICT RULES
+- If ANYTHING is unclear, STOP and ask me for clarification
+- Do NOT make design decisions - ask me instead
+- Do NOT add features I didn't explicitly request
+- Do NOT refactor code unless that IS the requested task
+- Do NOT create helper functions unless explicitly asked
+- Do NOT add error handling unless specified
+- Do NOT add tests unless requested
+- Do NOT improve or optimize unless that's the specific task
+
+## Task
+- Add a 'saveState' function in LocalStorageService that takes in a `State` object from src/app/2. store/index.ts.
+- Add a 'getState' function in LocalStorageService that returns a `State` object. This function will deserialize the full state object retrieved from local storage. If there isn't one in local storage or the deserialization fails, then null will be returned, and local storage will be cleared.
+
+## File(s) to modify
+- local-storage.service.ts
+- local-storage.service.spec.ts
+
+## Current behavior
+- LocalStorageService is an empty service, at the moment.
+
+## Required behavior
+- New `saveState` function will serialize the full `State` object and put it in local storage, using the key `palabs-app-state`.
+- `saveState` will overwrite anything in local storage that is using the same key.
+- If `saveState` fails for whatever reason, return false. If it succeeds, return true.
+- New `getState` function will deserialize the full `State` object out of local storage, using the same key.
+- If nothing is in local storage, then `getState` will return null.
+- If `State` can't be properly deserialized out of local storage, then clear whatever is in storage with this key and return then return null.
+- Put a JS doc style comment on top of the `saveState` function, but don't comment on behavior in the function itself.
+- Put a JS doc style comment on top of the `getState` function, but don't comment on behavior in the function itself.
+- Put a JS doc style comment on top of the `LocalStorageService` class.
+
+## Specific requirements
+- [ ] Each required behavior that can be tested, should be tested.
+- [ ] When complete each task and requirement, commit and push.
+- [ ] After pushing the feature, /export this conversation to a file you'll create at claude-tasks/2_implement_local_storage_service/chat.md.
+
+## What you may NOT do
+- Do not modify any other files
+- Do not add functionality beyond what's listed
+- Do not make stylistic changes
+- Do not add comments unless requested
+- Do not change variable names unless requested
+
+## If you need to know
+- Ask about function signatures before creating them
+- Ask about variable names before introducing them
+- Ask about error handling approach if errors might occur
+- Ask about import statements if you need new ones
+- Ask about code style if you're unsure
+
+IMPORTANT: If you cannot complete this task without making assumptions, list your questions BEFORE writing any code.
+```
+
+## Questions Claude MUST Ask (Examples)
+
+### When function signature is unclear:
+"You want me to add a validation function, but you haven't specified:
+- Should it be named `validateUser` or something else?
+- Should it return boolean or throw an error?
+- Should it take a user object or individual parameters?
+Please specify the exact function signature you want."
+
+### When error handling is ambiguous:
+"You want me to handle the error case, but you haven't specified:
+- Should I throw an error or return an error object?
+- What should the exact error message be?
+- Should I use a custom error class or standard Error?
+Please specify exactly how to handle this error."
+
+### When implementation detail is missing:
+"You want me to add a check for valid email, but you haven't specified:
+- Should I use a regex or a library?
+- What exact email validation rules do you want?
+- Should invalid emails throw or return false?
+Please specify the exact validation logic you want."
+
+## Atomic Commit Guidelines
+
+Each task should result in ONE commit that:
+- Changes ONE logical thing
+- Can be reverted without breaking other features
+- Has a clear, single purpose
+- Is complete and working on its own
+
+### Examples of Atomic Tasks:
+✅ "Add null check to getUserById function"
+✅ "Change error message in validateEmail from 'bad email' to 'Invalid email format'"
+✅ "Add new optional parameter 'timeout' to fetchData function"
+
+### Examples of Non-Atomic Tasks (Split these up):
+❌ "Add validation to all user functions" → Split into one task per function
+❌ "Fix bug and add logging" → Split into two tasks
+❌ "Refactor and add new feature" → Split into separate tasks
+
+## The Nuclear Option
+
+If Claude starts making assumptions or being creative, use this:
+
+```
+STOP. You are making assumptions. 
+
+STRICT MODE ACTIVATED.
+
+You may ONLY:
+1. Write the EXACT code I describe
+2. In the EXACT location I specify  
+3. With the EXACT behavior I define
+
+If ANYTHING is unclear, you must ask. Do not proceed without explicit answers.
+
+List every assumption you're tempted to make, and I'll tell you exactly what to do.
+```
+
+## Verification Checklist
+
+Before Claude writes code, ensure:
+- [ ] The task is ONE atomic change
+- [ ] Every detail is explicitly specified
+- [ ] File paths are exact
+- [ ] Function/variable names are provided
+- [ ] Error messages are exact strings
+- [ ] No room for interpretation exists
+
+## Red Flags - When Claude Should STOP
+
+Claude should refuse to continue if:
+- "Make it better" without specifics
+- "Fix all the issues" without listing them
+- "Add appropriate error handling" without details
+- "Refactor as needed" without constraints
+- "Use best practices" without defining them
+- "Add necessary validation" without specifications
+- "Improve performance" without metrics
+- "Clean up the code" without specific problems
+
+Remember: It's better for Claude to ask 10 clarifying questions than to make 1 assumption.

--- a/src/app/3. services/local-storage.service.spec.ts
+++ b/src/app/3. services/local-storage.service.spec.ts
@@ -55,7 +55,7 @@ describe('LocalStorageService', () => {
       expect(parsedState.game.mostRecentAnswer).toEqual(mockState.game.mostRecentAnswer);
       expect(parsedState.game.score).toEqual(mockState.game.score);
       // Check scrambledLetters array - undefined typedIndex will be missing after serialization
-      expect(parsedState.game.scrambledLetters).toHaveSize(4);
+      expect(parsedState.game.scrambledLetters).toHaveLength(4);
       expect(parsedState.game.scrambledLetters[0]).toEqual(jasmine.objectContaining({ value: 'T', index: 0 }));
       expect(parsedState.game.scrambledLetters[1]).toEqual(jasmine.objectContaining({ value: 'E', index: 1 }));
       expect(parsedState.game.scrambledLetters[2]).toEqual(jasmine.objectContaining({ value: 'S', index: 2 }));

--- a/src/app/3. services/local-storage.service.spec.ts
+++ b/src/app/3. services/local-storage.service.spec.ts
@@ -100,7 +100,7 @@ describe('LocalStorageService', () => {
       expect(result!.game.mostRecentAnswer).toEqual(mockState.game.mostRecentAnswer);
       expect(result!.game.score).toEqual(mockState.game.score);
       // Check scrambledLetters array - undefined typedIndex will be missing after deserialization
-      expect(result!.game.scrambledLetters).toHaveSize(4);
+      expect(result!.game.scrambledLetters).toHaveLength(4);
       expect(result!.game.scrambledLetters[0]).toEqual(jasmine.objectContaining({ value: 'T', index: 0 }));
       expect(result!.game.scrambledLetters[1]).toEqual(jasmine.objectContaining({ value: 'E', index: 1 }));
       expect(result!.game.scrambledLetters[2]).toEqual(jasmine.objectContaining({ value: 'S', index: 2 }));

--- a/src/app/3. services/local-storage.service.spec.ts
+++ b/src/app/3. services/local-storage.service.spec.ts
@@ -1,16 +1,134 @@
 import { TestBed } from '@angular/core/testing';
 
 import { LocalStorageService } from './local-storage.service';
+import { State } from '../2. store';
 
 describe('LocalStorageService', () => {
   let service: LocalStorageService;
+  const storageKey = 'palabs-app-state';
+
+  const mockState: State = {
+    game: {
+      answers: [
+        {
+          word: 'TEST',
+          letters: ['T', 'E', 'S', 'T'],
+          state: 'found',
+        },
+      ],
+      scrambledLetters: [
+        { value: 'T', index: 0, typedIndex: undefined },
+        { value: 'E', index: 1, typedIndex: undefined },
+        { value: 'S', index: 2, typedIndex: undefined },
+        { value: 'T', index: 3, typedIndex: undefined },
+      ],
+      mostRecentAnswer: 'TEST',
+      score: 100,
+    },
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({});
     service = TestBed.inject(LocalStorageService);
+    localStorage.clear();
+  });
+
+  afterEach(() => {
+    localStorage.clear();
   });
 
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  describe('saveState', () => {
+    it('should save state to localStorage and return true', () => {
+      const result = service.saveState(mockState);
+
+      expect(result).toBe(true);
+      const storedValue = localStorage.getItem(storageKey);
+      expect(storedValue).toBeTruthy();
+      
+      // Note: JSON.stringify/parse doesn't preserve undefined values - they are removed during serialization
+      const parsedState = JSON.parse(storedValue!);
+      expect(parsedState.game.answers).toEqual(mockState.game.answers);
+      expect(parsedState.game.mostRecentAnswer).toEqual(mockState.game.mostRecentAnswer);
+      expect(parsedState.game.score).toEqual(mockState.game.score);
+      // Check scrambledLetters array - undefined typedIndex will be missing after serialization
+      expect(parsedState.game.scrambledLetters).toHaveSize(4);
+      expect(parsedState.game.scrambledLetters[0]).toEqual(jasmine.objectContaining({ value: 'T', index: 0 }));
+      expect(parsedState.game.scrambledLetters[1]).toEqual(jasmine.objectContaining({ value: 'E', index: 1 }));
+      expect(parsedState.game.scrambledLetters[2]).toEqual(jasmine.objectContaining({ value: 'S', index: 2 }));
+      expect(parsedState.game.scrambledLetters[3]).toEqual(jasmine.objectContaining({ value: 'T', index: 3 }));
+    });
+
+    it('should overwrite existing state in localStorage', () => {
+      const firstState: State = {
+        game: {
+          ...mockState.game,
+          score: 50,
+        },
+      };
+
+      service.saveState(firstState);
+      const firstStoredValue = localStorage.getItem(storageKey);
+      expect(JSON.parse(firstStoredValue!).game.score).toBe(50);
+
+      service.saveState(mockState);
+      const secondStoredValue = localStorage.getItem(storageKey);
+      expect(JSON.parse(secondStoredValue!).game.score).toBe(100);
+    });
+
+    it('should return false if localStorage.setItem throws an error', () => {
+      spyOn(localStorage, 'setItem').and.throwError('Storage quota exceeded');
+
+      const result = service.saveState(mockState);
+
+      expect(result).toBe(false);
+    });
+  });
+
+  describe('getState', () => {
+    it('should retrieve and deserialize state from localStorage', () => {
+      localStorage.setItem(storageKey, JSON.stringify(mockState));
+
+      const result = service.getState();
+
+      // Note: JSON.stringify/parse doesn't preserve undefined values - they are removed during serialization
+      expect(result).toBeTruthy();
+      expect(result!.game.answers).toEqual(mockState.game.answers);
+      expect(result!.game.mostRecentAnswer).toEqual(mockState.game.mostRecentAnswer);
+      expect(result!.game.score).toEqual(mockState.game.score);
+      // Check scrambledLetters array - undefined typedIndex will be missing after deserialization
+      expect(result!.game.scrambledLetters).toHaveSize(4);
+      expect(result!.game.scrambledLetters[0]).toEqual(jasmine.objectContaining({ value: 'T', index: 0 }));
+      expect(result!.game.scrambledLetters[1]).toEqual(jasmine.objectContaining({ value: 'E', index: 1 }));
+      expect(result!.game.scrambledLetters[2]).toEqual(jasmine.objectContaining({ value: 'S', index: 2 }));
+      expect(result!.game.scrambledLetters[3]).toEqual(jasmine.objectContaining({ value: 'T', index: 3 }));
+    });
+
+    it('should return null if no state exists in localStorage', () => {
+      const result = service.getState();
+
+      expect(result).toBeNull();
+    });
+
+    it('should return null and clear localStorage if state cannot be deserialized', () => {
+      localStorage.setItem(storageKey, 'invalid json {');
+
+      const result = service.getState();
+
+      expect(result).toBeNull();
+      expect(localStorage.getItem(storageKey)).toBeNull();
+    });
+
+    it('should return null and clear localStorage if stored value is not valid JSON', () => {
+      localStorage.setItem(storageKey, 'undefined');
+
+      const result = service.getState();
+
+      expect(result).toBeNull();
+      expect(localStorage.getItem(storageKey)).toBeNull();
+    });
   });
 });

--- a/src/app/3. services/local-storage.service.spec.ts
+++ b/src/app/3. services/local-storage.service.spec.ts
@@ -55,7 +55,7 @@ describe('LocalStorageService', () => {
       expect(parsedState.game.mostRecentAnswer).toEqual(mockState.game.mostRecentAnswer);
       expect(parsedState.game.score).toEqual(mockState.game.score);
       // Check scrambledLetters array - undefined typedIndex will be missing after serialization
-      expect(parsedState.game.scrambledLetters).toHaveLength(4);
+      expect(parsedState.game.scrambledLetters).toHaveSize(4);
       expect(parsedState.game.scrambledLetters[0]).toEqual(jasmine.objectContaining({ value: 'T', index: 0 }));
       expect(parsedState.game.scrambledLetters[1]).toEqual(jasmine.objectContaining({ value: 'E', index: 1 }));
       expect(parsedState.game.scrambledLetters[2]).toEqual(jasmine.objectContaining({ value: 'S', index: 2 }));

--- a/src/app/3. services/local-storage.service.spec.ts
+++ b/src/app/3. services/local-storage.service.spec.ts
@@ -100,7 +100,7 @@ describe('LocalStorageService', () => {
       expect(result!.game.mostRecentAnswer).toEqual(mockState.game.mostRecentAnswer);
       expect(result!.game.score).toEqual(mockState.game.score);
       // Check scrambledLetters array - undefined typedIndex will be missing after deserialization
-      expect(result!.game.scrambledLetters).toHaveLength(4);
+      expect(result!.game.scrambledLetters).toHaveSize(4);
       expect(result!.game.scrambledLetters[0]).toEqual(jasmine.objectContaining({ value: 'T', index: 0 }));
       expect(result!.game.scrambledLetters[1]).toEqual(jasmine.objectContaining({ value: 'E', index: 1 }));
       expect(result!.game.scrambledLetters[2]).toEqual(jasmine.objectContaining({ value: 'S', index: 2 }));

--- a/src/app/3. services/local-storage.service.ts
+++ b/src/app/3. services/local-storage.service.ts
@@ -1,6 +1,45 @@
 import { Injectable } from '@angular/core';
+import { State } from '../2. store';
 
+/**
+ * Service for managing application state persistence in local storage
+ */
 @Injectable({
   providedIn: 'root',
 })
-export class LocalStorageService {}
+export class LocalStorageService {
+  private readonly storageKey = 'palabs-app-state';
+
+  /**
+   * Saves the application state to local storage
+   * @param state The current application state to save
+   * @returns true if the save was successful, false otherwise
+   */
+  saveState(state: State): boolean {
+    try {
+      const serializedState = JSON.stringify(state);
+      localStorage.setItem(this.storageKey, serializedState);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Retrieves the application state from local storage
+   * @returns The deserialized state object, or null if not found or deserialization fails
+   */
+  getState(): State | null {
+    try {
+      const serializedState = localStorage.getItem(this.storageKey);
+      if (serializedState === null) {
+        return null;
+      }
+      const state = JSON.parse(serializedState) as State;
+      return state;
+    } catch {
+      localStorage.removeItem(this.storageKey);
+      return null;
+    }
+  }
+}


### PR DESCRIPTION
## Pull Request Overview

This PR implements the missing `getState` and `saveState` methods in the `LocalStorageService` to enable application state persistence. The implementation allows the service to serialize and store the complete application state in localStorage and retrieve it later.

- Adds `saveState` method that serializes State objects to localStorage with error handling
- Adds `getState` method that deserializes State objects from localStorage with fallback clearing
- Includes comprehensive unit tests covering success cases, error scenarios, and edge cases

### Reviewed Changes

Copilot reviewed 4 out of 4 changed files in this pull request and generated 3 comments.

| File | Description |
| ---- | ----------- |
| `src/app/3. services/local-storage.service.ts` | Implements the core functionality with saveState and getState methods plus JSDoc documentation |
| `src/app/3. services/local-storage.service.spec.ts` | Adds comprehensive unit tests covering all scenarios and edge cases |
| `claude-tasks/2_implement_local_storage_service/prompt.md` | Documents the implementation requirements and guidelines |
| `claude-tasks/2_implement_local_storage_service/chat.md` | Records the implementation process and technical decisions |