### PR TITLE
feat: add clearState function to LocalStorageService

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,8 +11,7 @@
       "Bash(npm test:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
-      "Bash(git push:*)",
-      "Bash(/export claude-tasks/3_local_storage_service_clear_state/chat.md)"
+      "Bash(git push:*)"
     ],
     "deny": [],
     "ask": []

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -11,7 +11,8 @@
       "Bash(npm test:*)",
       "Bash(git add:*)",
       "Bash(git commit:*)",
-      "Bash(git push:*)"
+      "Bash(git push:*)",
+      "Bash(/export claude-tasks/3_local_storage_service_clear_state/chat.md)"
     ],
     "deny": [],
     "ask": []

--- a/claude-tasks/3_local_storage_service_clear_state/chat.md
+++ b/claude-tasks/3_local_storage_service_clear_state/chat.md
@@ -1,0 +1,74 @@
+# LocalStorageService clearState Implementation
+
+## Task Summary
+Implemented the `clearState` function for the LocalStorageService to clear application state from local storage.
+
+## Implementation Details
+
+### Changes Made
+
+1. **Added `clearState` method to LocalStorageService** (`src/app/3. services/local-storage.service.ts`)
+   - Added a new public method that removes the state from localStorage using the existing storage key
+   - Added JSDoc comment as required
+
+2. **Added comprehensive tests** (`src/app/3. services/local-storage.service.spec.ts`)
+   - Test case 1: Clears state when state exists in localStorage
+     - Uses `saveState` to save mock state
+     - Uses `getState` to verify state exists before clearing
+     - Calls `clearState` to clear the state
+     - Uses `getState` to verify state is cleared
+   - Test case 2: Clears state when no state exists  
+     - Uses `getState` to verify no state exists initially
+     - Calls `clearState` to clear (no-op scenario)
+     - Uses `getState` to verify state remains null
+
+### Code Added
+
+#### LocalStorageService (`local-storage.service.ts`)
+```typescript
+/**
+ * Clears the application state from local storage
+ */
+clearState(): void {
+  localStorage.removeItem(this.storageKey);
+}
+```
+
+#### Tests (`local-storage.service.spec.ts`)
+```typescript
+describe('clearState', () => {
+  it('should clear state from localStorage when state exists', () => {
+    service.saveState(mockState);
+    const stateBeforeClear = service.getState();
+    expect(stateBeforeClear).toBeTruthy();
+
+    service.clearState();
+
+    const stateAfterClear = service.getState();
+    expect(stateAfterClear).toBeNull();
+    expect(localStorage.getItem(storageKey)).toBeNull();
+  });
+
+  it('should clear state from localStorage when no state exists', () => {
+    const stateBeforeClear = service.getState();
+    expect(stateBeforeClear).toBeNull();
+
+    service.clearState();
+
+    const stateAfterClear = service.getState();
+    expect(stateAfterClear).toBeNull();
+    expect(localStorage.getItem(storageKey)).toBeNull();
+  });
+});
+```
+
+## Verification
+
+- ✅ All tests pass (10 of 10 SUCCESS)
+- ✅ 100% code coverage maintained
+- ✅ Linting passes with no errors
+- ✅ Changes committed and pushed to branch `atarr/develop/local-storage-service-clear-state`
+
+## Commit Details
+- Commit hash: e606dfa
+- Commit message: "feat: add clearState function to LocalStorageService"

--- a/claude-tasks/3_local_storage_service_clear_state/prompt.md
+++ b/claude-tasks/3_local_storage_service_clear_state/prompt.md
@@ -1,0 +1,158 @@
+# Claude Code Prompt Template for Atomic Feature Development
+
+## Core Directive
+
+You are operating under STRICT IMPLEMENTATION MODE. You must:
+
+1. NEVER make assumptions or "fill in the blanks"
+2. STOP and ASK when any detail is unclear
+3. REFUSE to implement if specifications are ambiguous
+4. ONLY write code that is explicitly requested
+5. CREATE only atomic, single-purpose changes
+
+## Prompt Template
+
+```
+I need you to implement the following specific change. This should be ONE atomic commit.
+
+## STRICT RULES
+- If ANYTHING is unclear, STOP and ask me for clarification
+- Do NOT make design decisions - ask me instead
+- Do NOT add features I didn't explicitly request
+- Do NOT refactor code unless that IS the requested task
+- Do NOT create helper functions unless explicitly asked
+- Do NOT add error handling unless specified
+- Do NOT add tests unless requested
+- Do NOT improve or optimize unless that's the specific task
+
+## Task
+- Add a `clearState` function to LocalStorageService.
+
+## File(s) to modify
+- src/app/services/local-storage.service.ts
+- src/app/services/local-storage.service.spec.ts
+
+## Current behavior
+- There is no `clearState` function in LocalStorageService.
+
+## Required behavior
+- New `clearState` function will clear local storage at the state key. It doesn't matter if state is empty or not.
+- Put a JS doc style comment on top of the `clearState` function, but don't comment on behavior in the function itself.
+- `clearState` should be tested with and without state in it. You should utilize `getState` and `setState` in these tests.
+
+## Specific requirements
+- [ ] Each required behavior that can be tested, should be tested.
+- [ ] When complete each task and requirement, commit and push.
+- [ ] After pushing the feature, /export this conversation to a file you'll create at claude-tasks/2_implement_local_storage_service/chat.md.
+
+## What you may NOT do
+- Do not modify any other files
+- Do not add functionality beyond what's listed
+- Do not make stylistic changes
+- Do not add comments unless requested
+- Do not change variable names unless requested
+
+## If you need to know
+- Ask about function signatures before creating them
+- Ask about variable names before introducing them
+- Ask about error handling approach if errors might occur
+- Ask about import statements if you need new ones
+- Ask about code style if you're unsure
+
+IMPORTANT: If you cannot complete this task without making assumptions, list your questions BEFORE writing any code.
+```
+
+## Questions Claude MUST Ask (Examples)
+
+### When function signature is unclear:
+
+"You want me to add a validation function, but you haven't specified:
+
+- Should it be named `validateUser` or something else?
+- Should it return boolean or throw an error?
+- Should it take a user object or individual parameters?
+  Please specify the exact function signature you want."
+
+### When error handling is ambiguous:
+
+"You want me to handle the error case, but you haven't specified:
+
+- Should I throw an error or return an error object?
+- What should the exact error message be?
+- Should I use a custom error class or standard Error?
+  Please specify exactly how to handle this error."
+
+### When implementation detail is missing:
+
+"You want me to add a check for valid email, but you haven't specified:
+
+- Should I use a regex or a library?
+- What exact email validation rules do you want?
+- Should invalid emails throw or return false?
+  Please specify the exact validation logic you want."
+
+## Atomic Commit Guidelines
+
+Each task should result in ONE commit that:
+
+- Changes ONE logical thing
+- Can be reverted without breaking other features
+- Has a clear, single purpose
+- Is complete and working on its own
+
+### Examples of Atomic Tasks:
+
+✅ "Add null check to getUserById function"
+✅ "Change error message in validateEmail from 'bad email' to 'Invalid email format'"
+✅ "Add new optional parameter 'timeout' to fetchData function"
+
+### Examples of Non-Atomic Tasks (Split these up):
+
+❌ "Add validation to all user functions" → Split into one task per function
+❌ "Fix bug and add logging" → Split into two tasks
+❌ "Refactor and add new feature" → Split into separate tasks
+
+## The Nuclear Option
+
+If Claude starts making assumptions or being creative, use this:
+
+```
+STOP. You are making assumptions.
+
+STRICT MODE ACTIVATED.
+
+You may ONLY:
+1. Write the EXACT code I describe
+2. In the EXACT location I specify
+3. With the EXACT behavior I define
+
+If ANYTHING is unclear, you must ask. Do not proceed without explicit answers.
+
+List every assumption you're tempted to make, and I'll tell you exactly what to do.
+```
+
+## Verification Checklist
+
+Before Claude writes code, ensure:
+
+- [ ] The task is ONE atomic change
+- [ ] Every detail is explicitly specified
+- [ ] File paths are exact
+- [ ] Function/variable names are provided
+- [ ] Error messages are exact strings
+- [ ] No room for interpretation exists
+
+## Red Flags - When Claude Should STOP
+
+Claude should refuse to continue if:
+
+- "Make it better" without specifics
+- "Fix all the issues" without listing them
+- "Add appropriate error handling" without details
+- "Refactor as needed" without constraints
+- "Use best practices" without defining them
+- "Add necessary validation" without specifications
+- "Improve performance" without metrics
+- "Clean up the code" without specific problems
+
+Remember: It's better for Claude to ask 10 clarifying questions than to make 1 assumption.

--- a/claude-tasks/3_local_storage_service_clear_state/prompt.md
+++ b/claude-tasks/3_local_storage_service_clear_state/prompt.md
@@ -43,7 +43,7 @@ I need you to implement the following specific change. This should be ONE atomic
 ## Specific requirements
 - [ ] Each required behavior that can be tested, should be tested.
 - [ ] When complete each task and requirement, commit and push.
-- [ ] After pushing the feature, /export this conversation to a file you'll create at claude-tasks/2_implement_local_storage_service/chat.md.
+- [ ] After pushing the feature, /export this conversation to a file you'll create at claude-tasks/3_local_storage_service_clear_state/chat.md.
 
 ## What you may NOT do
 - Do not modify any other files

--- a/src/app/3. services/local-storage.service.spec.ts
+++ b/src/app/3. services/local-storage.service.spec.ts
@@ -131,4 +131,29 @@ describe('LocalStorageService', () => {
       expect(localStorage.getItem(storageKey)).toBeNull();
     });
   });
+
+  describe('clearState', () => {
+    it('should clear state from localStorage when state exists', () => {
+      service.saveState(mockState);
+      const stateBeforeClear = service.getState();
+      expect(stateBeforeClear).toBeTruthy();
+
+      service.clearState();
+
+      const stateAfterClear = service.getState();
+      expect(stateAfterClear).toBeNull();
+      expect(localStorage.getItem(storageKey)).toBeNull();
+    });
+
+    it('should clear state from localStorage when no state exists', () => {
+      const stateBeforeClear = service.getState();
+      expect(stateBeforeClear).toBeNull();
+
+      service.clearState();
+
+      const stateAfterClear = service.getState();
+      expect(stateAfterClear).toBeNull();
+      expect(localStorage.getItem(storageKey)).toBeNull();
+    });
+  });
 });

--- a/src/app/3. services/local-storage.service.ts
+++ b/src/app/3. services/local-storage.service.ts
@@ -42,4 +42,11 @@ export class LocalStorageService {
       return null;
     }
   }
+
+  /**
+   * Clears the application state from local storage
+   */
+  clearState(): void {
+    localStorage.removeItem(this.storageKey);
+  }
 }


### PR DESCRIPTION
## Pull Request Overview

This PR adds a new `clearState` function to the `LocalStorageService` to provide a way to clear application state from local storage. The implementation includes comprehensive test coverage for both scenarios where state exists and where no state is present.

- Add `clearState()` method to `LocalStorageService` that removes state from localStorage
- Include comprehensive test coverage for clearing state in both populated and empty scenarios
- Add documentation files describing the implementation task and chat history

### Reviewed Changes

Copilot reviewed 5 out of 5 changed files in this pull request and generated no comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/app/3. services/local-storage.service.ts | Adds new `clearState()` method with JSDoc documentation |
| src/app/3. services/local-storage.service.spec.ts | Adds test cases for clearing state when it exists and when it doesn't exist |
| claude-tasks/3_local_storage_service_clear_state/prompt.md | Documentation template for atomic feature development |
| claude-tasks/3_local_storage_service_clear_state/chat.md | Implementation summary and details |
| .claude/settings.local.json | Configuration update to allow export command |
</details>