### PR TITLE
Show new game button after reveal

### DIFF
--- a/src/app/1. features/game/game.component.html
+++ b/src/app/1. features/game/game.component.html
@@ -90,36 +90,36 @@
     }
   </section>
 
-  @if ({ isComplete: isGameComplete$ | async }; as vm) {
+  @if ({ isOver: isGameOver$ | async }; as vm) {
     <section class="flex-center-between" role="region" aria-label="Game controls">
       <button
         mat-raised-button
-        [disabled]="vm.isComplete"
+        [disabled]="vm.isOver"
         (click)="clickShuffle()"
         [attr.aria-label]="
-          vm.isComplete
-            ? 'Shuffle letters (disabled - game complete)'
+          vm.isOver
+            ? 'Shuffle letters (disabled - game over)'
             : 'Shuffle available letters'
         "
-        [attr.aria-disabled]="vm.isComplete"
+        [attr.aria-disabled]="vm.isOver"
       >
         <mat-icon aria-hidden="true">shuffle</mat-icon>
         Shuffle
       </button>
       <button
         mat-raised-button
-        [color]="vm.isComplete ? 'accent' : 'primary'"
-        (click)="clickEnter(!!vm.isComplete)"
+        [color]="vm.isOver ? 'accent' : 'primary'"
+        (click)="clickEnter(!!vm.isOver)"
         [attr.aria-label]="
-          vm.isComplete ? 'Start a new game' : 'Submit current word'
+          vm.isOver ? 'Start a new game' : 'Submit current word'
         "
       >
-        @if (vm.isComplete) {
+        @if (vm.isOver) {
           <mat-icon aria-hidden="true">refresh</mat-icon>
         } @else {
           <mat-icon aria-hidden="true">send</mat-icon>
         }
-        {{ vm.isComplete ? "Start New Game" : "Enter" }}
+        {{ vm.isOver ? "Start New Game" : "Enter" }}
       </button>
     </section>
   }

--- a/src/app/1. features/game/game.component.sass
+++ b/src/app/1. features/game/game.component.sass
@@ -43,3 +43,11 @@
   100%
     transform: translateY(0)
     opacity: 1
+
+.word-found
+  color: inherit
+
+.word-revealed
+  color: #888
+  font-style: italic
+  opacity: 0.8

--- a/src/app/1. features/game/game.component.ts
+++ b/src/app/1. features/game/game.component.ts
@@ -15,7 +15,7 @@ import {
   selectClickableLetters,
   selectClickedLetters,
   selectEarnedPoints,
-  selectIsGameComplete,
+  selectIsGameOver,
   selectMostRecentAnswer,
   selectPotentialPoints,
   selectScore,
@@ -38,7 +38,7 @@ export class GameComponent implements OnInit {
   public clickedLetters$: Observable<Letter[]>;
   public earnedPoints$: Observable<number>;
   public potentialPoints$: Observable<number>;
-  public isGameComplete$: Observable<boolean>;
+  public isGameOver$: Observable<boolean>;
   public score$: Observable<number>;
   public mostRecentAnswer$: Observable<string | undefined>;
 
@@ -48,7 +48,7 @@ export class GameComponent implements OnInit {
     this.clickedLetters$ = this.store.select(selectClickedLetters);
     this.earnedPoints$ = this.store.select(selectEarnedPoints);
     this.potentialPoints$ = this.store.select(selectPotentialPoints);
-    this.isGameComplete$ = this.store.select(selectIsGameComplete);
+    this.isGameOver$ = this.store.select(selectIsGameOver);
     this.score$ = this.store.select(selectScore);
     this.mostRecentAnswer$ = this.store.select(selectMostRecentAnswer);
   }
@@ -76,10 +76,10 @@ export class GameComponent implements OnInit {
 
   /**
    * Handles enter button click events
-   * @param isGameComplete Whether the current game is complete
+   * @param isGameOver Whether the current game is over
    */
-  public clickEnter(isGameComplete: boolean): void {
-    if (isGameComplete) {
+  public clickEnter(isGameOver: boolean): void {
+    if (isGameOver) {
       this.store.dispatch(newGameAfterCompletion());
     } else {
       this.store.dispatch(wordSubmitted());

--- a/src/app/1. features/shared/header/header.component.html
+++ b/src/app/1. features/shared/header/header.component.html
@@ -1,13 +1,21 @@
 <header role="banner">
-  <mat-toolbar role="navigation" aria-label="Main navigation">
-    <button
-      mat-icon-button
-      [matMenuTriggerFor]="menu"
-      class="example-icon"
-      aria-label="Open game menu"
-    >
-      <mat-icon aria-hidden="true">menu</mat-icon>
-    </button>
+  <mat-toolbar role="navigation" aria-label="Main navigation" class="toolbar-container">
+    <div class="toolbar-spacer"></div>
+    
+    <h1 class="toolbar-title" aria-label="Palabritas word game">
+      Palabritas
+    </h1>
+
+    <div class="toolbar-actions">
+      <button
+        mat-icon-button
+        [matMenuTriggerFor]="menu"
+        class="example-icon"
+        aria-label="Open game menu"
+      >
+        <mat-icon aria-hidden="true">menu</mat-icon>
+      </button>
+    </div>
     <mat-menu #menu="matMenu" aria-label="Game options">
       <button
         mat-menu-item
@@ -26,20 +34,19 @@
         <mat-icon aria-hidden="true">refresh</mat-icon>
         <span>New Game</span>
       </button>
+
+      <mat-divider></mat-divider>
+
+      <a
+        mat-menu-item
+        target="_blank"
+        rel="noopener noreferrer"
+        href="https://github.com/tarrball/palabritas"
+        aria-label="View source code on GitHub (opens in new tab)"
+      >
+        <mat-icon aria-hidden="true">code</mat-icon>
+        <span>GitHub</span>
+      </a>
     </mat-menu>
-
-    <h1 class="flex-grow-1 text-align-center" aria-label="Palabritas word game">
-      Palabritas
-    </h1>
-
-    <a
-      class="github-logo d-flex align-items-center"
-      target="_blank"
-      rel="noopener noreferrer"
-      href="https://github.com/tarrball/palabritas"
-      aria-label="View Palabritas source code on GitHub (opens in new tab)"
-    >
-      <img src="../../../assets/github-mark-white.png" alt="GitHub logo" />
-    </a>
   </mat-toolbar>
 </header>

--- a/src/app/1. features/shared/header/header.component.sass
+++ b/src/app/1. features/shared/header/header.component.sass
@@ -1,11 +1,22 @@
-h1
+.toolbar-container
+  display: flex
+  justify-content: space-between
+  align-items: center
+
+.toolbar-spacer, .toolbar-actions
+  flex: 1
+  display: flex
+
+.toolbar-spacer
+  justify-content: flex-start
+
+.toolbar-actions
+  justify-content: flex-end
+
+.toolbar-title
   margin: 0
   font-size: 1.25rem
   font-weight: 500
-
-.github-logo
-  cursor: pointer
-  padding: 12px
-
-  img
-    height: 24px
+  position: absolute
+  left: 50%
+  transform: translateX(-50%)

--- a/src/app/1. features/shared/header/header.component.ts
+++ b/src/app/1. features/shared/header/header.component.ts
@@ -1,5 +1,6 @@
 import { Component, inject } from '@angular/core';
 import { MatButtonModule } from '@angular/material/button';
+import { MatDividerModule } from '@angular/material/divider';
 import { MatIconModule } from '@angular/material/icon';
 import { MatMenuModule } from '@angular/material/menu';
 import { MatToolbarModule } from '@angular/material/toolbar';
@@ -14,7 +15,7 @@ import {
   templateUrl: './header.component.html',
   styleUrls: ['./header.component.sass'],
   standalone: true,
-  imports: [MatButtonModule, MatIconModule, MatMenuModule, MatToolbarModule],
+  imports: [MatButtonModule, MatDividerModule, MatIconModule, MatMenuModule, MatToolbarModule],
 })
 export class HeaderComponent {
   private readonly store = inject(Store);

--- a/src/app/2. store/game/game.selectors.spec.ts
+++ b/src/app/2. store/game/game.selectors.spec.ts
@@ -3,7 +3,7 @@ import {
   selectClickableLetters,
   selectClickedLetters,
   selectEarnedPoints,
-  selectIsGameComplete,
+  selectIsGameOver,
   selectMostRecentAnswer,
   selectPotentialPoints,
   selectScore,
@@ -117,29 +117,40 @@ describe('GameSelectors', () => {
   });
 
   describe('selecting game state', () => {
-    describe('selectIsGameComplete', () => {
+    describe('selectIsGameOver', () => {
       it('should return true when all answers are found', () => {
         const state = generateGameState(3);
         state.answers.forEach(answer => answer.state = 'found');
 
-        const result = selectIsGameComplete.projector(state.answers);
+        const result = selectIsGameOver.projector(state.answers);
 
         expect(result).toBe(true);
       });
 
-      it('should return false when some answers are not found', () => {
+      it('should return true when any answer is revealed', () => {
+        const state = generateGameState(3);
+        state.answers[0].state = 'found';
+        state.answers[1].state = 'revealed';
+        state.answers[2].state = 'not-found';
+
+        const result = selectIsGameOver.projector(state.answers);
+
+        expect(result).toBe(true);
+      });
+
+      it('should return false when some answers are not found and none are revealed', () => {
         const state = generateGameState(3);
         state.answers[0].state = 'found';
         state.answers[1].state = 'not-found';
         state.answers[2].state = 'found';
 
-        const result = selectIsGameComplete.projector(state.answers);
+        const result = selectIsGameOver.projector(state.answers);
 
         expect(result).toBe(false);
       });
 
       it('should return false when there are no answers', () => {
-        const result = selectIsGameComplete.projector([]);
+        const result = selectIsGameOver.projector([]);
 
         expect(result).toBe(false);
       });

--- a/src/app/2. store/game/game.selectors.ts
+++ b/src/app/2. store/game/game.selectors.ts
@@ -34,8 +34,11 @@ export const selectPotentialPoints = createSelector(selectAnswers, (answers) =>
   answers.reduce(pointsReducer, 0)
 );
 
-export const selectIsGameComplete = createSelector(selectAnswers, (answers) =>
-  answers.length > 0 && answers.every((answer) => answer.state === 'found')
+export const selectIsGameOver = createSelector(selectAnswers, (answers) =>
+  answers.length > 0 && (
+    answers.every((answer) => answer.state === 'found') ||
+    answers.some((answer) => answer.state === 'revealed')
+  )
 );
 
 export const selectScore = createSelector(selectFeature, (state) => state.score);


### PR DESCRIPTION
## Pull Request Overview

This PR changes the game completion logic to show the "New Game" button when any answer is revealed, not just when all answers are found. The change expands the game-over condition to include scenarios where players reveal answers before finding all words.

- Renamed `selectIsGameComplete` to `selectIsGameOver` to better reflect the expanded functionality
- Updated game-over logic to trigger when any answer is revealed OR all answers are found
- Refactored header component layout to center the title with actions on the right

### Reviewed Changes

Copilot reviewed 8 out of 8 changed files in this pull request and generated no comments.

<details>
<summary>Show a summary per file</summary>

| File | Description |
| ---- | ----------- |
| src/app/2. store/game/game.selectors.ts | Updated selector logic to check for revealed answers in addition to found answers |
| src/app/2. store/game/game.selectors.spec.ts | Added test coverage for the new revealed answer scenario |
| src/app/1. features/shared/header/header.component.ts | Added MatDividerModule import for menu styling |
| src/app/1. features/shared/header/header.component.sass | Restructured toolbar layout with flexbox for centered title |
| src/app/1. features/shared/header/header.component.html | Reorganized toolbar structure and converted GitHub link to menu item |
| src/app/1. features/game/game.component.ts | Updated references from game complete to game over |
| src/app/1. features/game/game.component.sass | Added CSS classes for styling found vs revealed words |
| src/app/1. features/game/game.component.html | Updated template to use new game-over selector |
</details>