### PR TITLE
Adding e2e tests and fixing a score reset bug in new game reducer

### DIFF
--- a/src/app/2. store/game/game.reducer.spec.ts
+++ b/src/app/2. store/game/game.reducer.spec.ts
@@ -55,6 +55,24 @@ describe('GameReducer', () => {
       expect(nextState.scrambledLetters).toEqual([]);
       expect(nextState.mostRecentAnswer).toBeUndefined();
     });
+
+    it('should reset score to 0 if any answers were revealed', () => {
+      const stateWithRevealedAnswers: GameState = {
+        ...initialState,
+        score: 150,
+        answers: [
+          { word: 'test', letters: ['t', 'e', 's', 't'], state: 'found' },
+          { word: 'set', letters: ['s', 'e', 't'], state: 'revealed' }
+        ],
+      };
+      
+      const nextState = gameReducer(stateWithRevealedAnswers, newGameAfterCompletion());
+
+      expect(nextState.score).toBe(0);
+      expect(nextState.answers).toEqual([]);
+      expect(nextState.scrambledLetters).toEqual([]);
+      expect(nextState.mostRecentAnswer).toBeUndefined();
+    });
   });
 
   describe('newGameStarted', () => {

--- a/src/app/2. store/game/game.reducer.ts
+++ b/src/app/2. store/game/game.reducer.ts
@@ -39,8 +39,6 @@ export const gameReducer = createReducer(
       draft.score = state.answers.some((a) => a.state === 'revealed')
         ? 0
         : state.score;
-
-      return draft;
     })
   ),
   on(newGameStarted, (state, { word, answers }) =>

--- a/src/app/2. store/game/game.reducer.ts
+++ b/src/app/2. store/game/game.reducer.ts
@@ -34,8 +34,13 @@ export const gameReducer = createReducer(
   ),
   on(newGameAfterCompletion, (state) =>
     produce(initialState, (draft) => {
-      // Reset to initial state but preserve the score from completed game
-      draft.score = state.score;
+      // Reset to initial state but preserve the score from completed game,
+      // unless they revealed the answers.
+      draft.score = state.answers.some((a) => a.state === 'revealed')
+        ? 0
+        : state.score;
+
+      return draft;
     })
   ),
   on(newGameStarted, (state, { word, answers }) =>
@@ -48,7 +53,7 @@ export const gameReducer = createReducer(
 
       const letters = Array.from(word);
       const shuffledLetters = shuffleArray(letters);
-      
+
       draft.scrambledLetters = shuffledLetters.map((letter, index) => ({
         value: letter,
         index,
@@ -108,17 +113,17 @@ export const gameReducer = createReducer(
       const currentOrder = draft.scrambledLetters.map((l) => l.value).join('');
       let shuffled = [...draft.scrambledLetters];
       let newOrder = currentOrder;
-      
+
       // Keep shuffling until we get a different arrangement (with max attempts for edge cases)
       let attempts = 0;
       const maxAttempts = 10;
-      
+
       while (newOrder === currentOrder && attempts < maxAttempts) {
         shuffled = shuffleArray(draft.scrambledLetters);
         newOrder = shuffled.map((l) => l.value).join('');
         attempts++;
       }
-      
+
       // Update the scrambled letters with the new order
       draft.scrambledLetters = shuffled.map((letter, index) => ({
         ...letter,

--- a/src/app/e2e/hydration.e2e.spec.ts
+++ b/src/app/e2e/hydration.e2e.spec.ts
@@ -1,0 +1,133 @@
+import { TestBed } from '@angular/core/testing';
+import { Store, StoreModule } from '@ngrx/store';
+import { EffectsModule } from '@ngrx/effects';
+import { GameEffects } from '../2. store/game/game.effects';
+import { HydrationEffects } from '../2. store/hydration/hydration.effects';
+import { PersistenceEffects } from '../2. store/persistence/persistence.effects';
+import { GameService } from '../3. services/game.service';
+import {
+  letterTapped,
+  wordSubmitted,
+  newGameAfterCompletion,
+  revealGameRequested,
+} from '../2. store/game/game.actions';
+import {
+  selectScore,
+  selectAnswers,
+  selectFeature,
+  selectIsGameOver,
+} from '../2. store/game/game.selectors';
+import { reducers, metaReducers } from '../2. store';
+import { Letter } from '../2. store/game/game.state';
+import { LocalStorageService } from '../3. services/local-storage.service';
+
+describe('Hydration E2E', () => {
+  let store: Store;
+  let gameService: jasmine.SpyObj<GameService>;
+
+  beforeEach(() => {
+    localStorage.clear();
+
+    gameService = jasmine.createSpyObj('GameService', ['nextGame']);
+    gameService.nextGame.and.returnValues(
+      {
+        word: 'CAT',
+        answers: ['CAT', 'ACT', 'AT', 'TA'],
+      },
+      {
+        word: 'DOG',
+        answers: ['DOG', 'GOD', 'DO', 'GO'],
+      }
+    );
+
+    TestBed.configureTestingModule({
+      imports: [
+        StoreModule.forRoot(reducers, { metaReducers }),
+        EffectsModule.forRoot([
+          GameEffects,
+          HydrationEffects,
+          PersistenceEffects,
+        ]),
+      ],
+      providers: [{ provide: GameService, useValue: gameService }],
+    });
+
+    store = TestBed.inject(Store);
+  });
+
+  it('should preserve score when starting new game after completion', () => {
+    // Find a word to get some score
+    const gameState = store.selectSignal(selectFeature)();
+    const letters = gameState.scrambledLetters;
+    const cIndex = letters.findIndex((l: Letter) => l.value === 'C');
+    const aIndex = letters.findIndex((l: Letter) => l.value === 'A');
+    const tIndex = letters.findIndex((l: Letter) => l.value === 'T');
+
+    store.dispatch(letterTapped({ index: cIndex }));
+    store.dispatch(letterTapped({ index: aIndex }));
+    store.dispatch(letterTapped({ index: tIndex }));
+    store.dispatch(wordSubmitted());
+
+    let score = store.selectSignal(selectScore)();
+    expect(score).toBe(30);
+
+    // Use newGameAfterCompletion action
+    store.dispatch(newGameAfterCompletion());
+
+    // Score should be preserved
+    score = store.selectSignal(selectScore)();
+    expect(score).toBe(30);
+
+    // New game should have started
+    const answers = store.selectSignal(selectAnswers)();
+    expect(answers.map((a) => a.word)).toContain('DOG');
+
+    const localStorageService = TestBed.inject(LocalStorageService);
+    const cachedState = localStorageService.getState();
+    expect(cachedState!.game.score).toBe(30);
+  });
+
+  it('should reset score when starting a new game after reveal', () => {
+    // Find a word to get some score
+    const gameState = store.selectSignal(selectFeature)();
+    const letters = gameState.scrambledLetters;
+    const cIndex = letters.findIndex((l: Letter) => l.value === 'C');
+    const aIndex = letters.findIndex((l: Letter) => l.value === 'A');
+    const tIndex = letters.findIndex((l: Letter) => l.value === 'T');
+
+    store.dispatch(letterTapped({ index: cIndex }));
+    store.dispatch(letterTapped({ index: aIndex }));
+    store.dispatch(letterTapped({ index: tIndex }));
+    store.dispatch(wordSubmitted());
+
+    let score = store.selectSignal(selectScore)();
+    expect(score).toBe(30);
+
+    // Reveal the game
+    store.dispatch(revealGameRequested());
+
+    // Verify game is over after reveal
+    const isGameOver = store.selectSignal(selectIsGameOver)();
+    expect(isGameOver).toBe(true);
+
+    // Score should still be 30 after reveal
+    score = store.selectSignal(selectScore)();
+    expect(score).toBe(30);
+
+    // Start a new game after reveal
+    store.dispatch(newGameAfterCompletion());
+
+    // Score should be reset to 0
+    score = store.selectSignal(selectScore)();
+    expect(score).toBe(0);
+
+    // New game should have started
+    const answers = store.selectSignal(selectAnswers)();
+    expect(answers.map((a) => a.word)).toContain('DOG');
+    expect(answers.every((a) => a.state === 'not-found')).toBe(true);
+
+    const localStorageService = TestBed.inject(LocalStorageService);
+    const cachedState = localStorageService.getState();
+    expect(cachedState!.game.score).toBe(0);
+  });
+});


### PR DESCRIPTION
## Pull Request Overview

This PR adds end-to-end tests for game hydration and fixes a bug in the score reset logic when starting a new game after revealing answers.

- Adds comprehensive e2e tests that verify score preservation and reset behavior across game sessions
- Fixes score reset logic to properly reset to 0 when starting a new game after revealing answers
- Adds unit tests to verify the corrected score reset behavior

### Reviewed Changes

Copilot reviewed 3 out of 3 changed files in this pull request and generated 1 comment.

| File | Description |
| ---- | ----------- |
| src/app/e2e/hydration.e2e.spec.ts | New e2e test file covering score preservation/reset scenarios across game sessions |
| src/app/2. store/game/game.reducer.ts | Fixed newGameAfterCompletion reducer to reset score when answers were revealed |
| src/app/2. store/game/game.reducer.spec.ts | Added unit test to verify score reset behavior when answers are revealed |





---

<sub>**Tip:** Customize your code reviews with copilot-instructions.md. <a href="/tarrball/palabritas/new/main/.github?filename=copilot-instructions.md" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">Create the file</a> or <a href="https://docs.github.com/en/copilot/customizing-copilot/adding-repository-custom-instructions-for-github-copilot" class="Link--inTextBlock" target="_blank" rel="noopener noreferrer">learn how to get started</a>.</sub>